### PR TITLE
Remove deleted parameter of resolveIntersectionInfo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ if ( intersection ) {
     // Check if this is a city object
     if ( object.isCityObject ) {
 
-        const data = object.resolveIntersectionInfo( intersection[ 0 ], cityjsonData )
+        const data = object.resolveIntersectionInfo( intersection[ 0 ] )
 
         const objectId = data.objectId; // This is the objectId of the city object hit by the ray
 

--- a/src/objects/CityObjectsInstancedMesh.d.ts
+++ b/src/objects/CityObjectsInstancedMesh.d.ts
@@ -38,8 +38,7 @@ export class CityObjectsInstancedMesh extends Mesh {
      * { vertexIndex, objectIndex, objectId, geometryIndex, boundaryIndex, objectTypeIndex, surfaceTypeIndex, lodIndex }
      * 
      * @param intersection The intersection (as returned from a `Raycaster`)
-     * @param citymodel The CityJSON model
      */
-    resolveIntersectionInfo( intersection: Object, citymodel: Object ): Object;
+    resolveIntersectionInfo( intersection: Object ): Object;
 
 }

--- a/src/objects/CityObjectsLines.d.ts
+++ b/src/objects/CityObjectsLines.d.ts
@@ -38,8 +38,7 @@ export class CityObjectsLines extends Mesh {
      * { vertexIndex, objectIndex, objectId, geometryIndex, boundaryIndex, objectTypeIndex, surfaceTypeIndex, lodIndex }
      * 
      * @param intersection The intersection (as returned from a `Raycaster`)
-     * @param citymodel The CityJSON model
      */
-    resolveIntersectionInfo( intersection: Object, citymodel: Object ): Object;
+    resolveIntersectionInfo( intersection: Object ): Object;
 
 }

--- a/src/objects/CityObjectsMesh.d.ts
+++ b/src/objects/CityObjectsMesh.d.ts
@@ -39,9 +39,8 @@ export class CityObjectsMesh extends Mesh {
      * { vertexIndex, objectIndex, objectId, geometryIndex, boundaryIndex, objectTypeIndex, surfaceTypeIndex, lodIndex }
      * 
      * @param intersection The intersection (as returned from a `Raycaster`)
-     * @param citymodel The CityJSON model
      */
-    resolveIntersectionInfo( intersection: Object, citymodel: Object ): Object;
+    resolveIntersectionInfo( intersection: Object ): Object;
 
     /**
      * Prepares the mesh geometry for conditional formatting, by creating a

--- a/src/objects/CityObjectsPoints.d.ts
+++ b/src/objects/CityObjectsPoints.d.ts
@@ -38,8 +38,7 @@ export class CityObjectsPoints extends Mesh {
      * { vertexIndex, objectIndex, objectId, geometryIndex, boundaryIndex, objectTypeIndex, surfaceTypeIndex, lodIndex }
      * 
      * @param intersection The intersection (as returned from a `Raycaster`)
-     * @param citymodel The CityJSON model
      */
-    resolveIntersectionInfo( intersection: Object, citymodel: Object ): Object;
+    resolveIntersectionInfo( intersection: Object ): Object;
 
 }


### PR DESCRIPTION
This follows-up 6e7344dacec5771e28eb946489694f3a814deca5 on the removal of `citymodel` parameter of `resolveIntersectionInfo` :
* Updates the documentation
* Updates the TypeScript definitions
