### PR TITLE
Fix Meshes TypeScript definitions

### DIFF
--- a/src/objects/CityObjectsInstancedMesh.d.ts
+++ b/src/objects/CityObjectsInstancedMesh.d.ts
@@ -11,16 +11,23 @@ import { GeometryData } from "../parsers/geometry/GeometryData";
  */
 export class CityObjectsInstancedMesh extends Mesh {
 
+    citymodel: Object;
+    isCityObject: true;
+    isCityObjectMesh: true;
+    supportsConditionalFormatting: true;
+    supportsMaterials: true;
+
     /**
      * Creates a CityObjectMesh from `GeometryData`
      * 
+     * @param citymodel The CityJSON model
      * @param vertices The list of vertices for the mesh
      * @param geometryData The geometry data with all other information (surfaceTypes etc.)
      * @param isntanceData The data of instanced (objectIds, objectTypes and geometryIds)
      * @param matrix A matrix to transform the mesh
      * @param material A material (preferably a `CityObjectsMaterial`)
      */
-    constructor ( vertices: Vector3[], geometryData: GeometryData, instanceData: Object, matrix: Matrix4, material: Material );
+    constructor ( citymodel: Object, vertices: Vector3[], geometryData: GeometryData, instanceData: Object, matrix: Matrix4, material: Material );
 
     /**
      * Returns the index of one vertex that was close to the intersection as

--- a/src/objects/CityObjectsLines.d.ts
+++ b/src/objects/CityObjectsLines.d.ts
@@ -12,15 +12,20 @@ import { GeometryData } from "../parsers/geometry/GeometryData";
  */
 export class CityObjectsLines extends Mesh {
 
+    citymodel: Object;
+    isCityObject: true;
+    isCityObjectLine: true;
+
     /**
      * Creates a CityObjectMesh from `GeometryData`
      * 
+     * @param citymodel The CityJSON model
      * @param vertices The list of vertices for the mesh
      * @param geometryData The geometry data with all other information (objectIds etc.)
      * @param matrix A matrix to transform the mesh
      * @param material A material (preferably a `CityObjectsMaterial`)
      */
-    constructor ( vertices: Vector3[], geometryData: GeometryData, matrix: Matrix4, material: Material );
+    constructor ( citymodel: Object, vertices: Vector3[], geometryData: GeometryData, matrix: Matrix4, material: Material );
 
     /**
      * Returns the index of one vertex that was close to the intersection as

--- a/src/objects/CityObjectsMesh.d.ts
+++ b/src/objects/CityObjectsMesh.d.ts
@@ -13,15 +13,22 @@ import { GeometryData } from "../parsers/geometry/GeometryData";
  */
 export class CityObjectsMesh extends Mesh {
 
+    citymodel: Object;
+    isCityObject: true;
+    isCityObjectMesh: true;
+    supportsConditionalFormatting: true;
+    supportsMaterials: true;
+
     /**
      * Creates a CityObjectMesh from `GeometryData`
      * 
+     * @param citymodel The CityJSON model
      * @param vertices The list of vertices for the mesh
      * @param geometryData The geometry data with all other information (objectIds etc.)
      * @param matrix A matrix to transform the mesh
      * @param material A material (preferably a `CityObjectsMaterial`)
      */
-    constructor ( vertices: Vector3[], geometryData: GeometryData, matrix: Matrix4, material: Material );
+    constructor ( citymodel: Object, vertices: Vector3[], geometryData: GeometryData, matrix: Matrix4, material: Material );
 
     /**
      * Returns the index of one vertex that was close to the intersection as

--- a/src/objects/CityObjectsPoints.d.ts
+++ b/src/objects/CityObjectsPoints.d.ts
@@ -12,15 +12,20 @@ import { GeometryData } from "../parsers/geometry/GeometryData";
  */
 export class CityObjectsPoints extends Mesh {
 
+    citymodel: Object;
+    isCityObject: true;
+    isCityObjectPoints: true;
+
     /**
      * Creates a CityObjectMesh from `GeometryData`
      * 
+     * @param citymodel The CityJSON model
      * @param vertices The list of vertices for the mesh
      * @param geometryData The geometry data with all other information (objectIds etc.)
      * @param matrix A matrix to transform the mesh
      * @param material A material (preferably a `CityObjectsMaterial`)
      */
-    constructor ( vertices: Vector3[], geometryData: GeometryData, matrix: Matrix4, material: Material );
+    constructor ( citymodel: Object, vertices: Vector3[], geometryData: GeometryData, matrix: Matrix4, material: Material );
 
     /**
      * Returns the index of one vertex that was close to the intersection as


### PR DESCRIPTION
This adds missing properties from Meshes classes in their TypeScript definitions, as well as adds the missing `citymodel` parameter of their constructor.