### PR TITLE
Fix lods Typescript type

### DIFF
--- a/src/parsers/CityJSONParser.d.ts
+++ b/src/parsers/CityJSONParser.d.ts
@@ -29,7 +29,7 @@ export class CityJSONParser {
      * of a vertex based on its `lodid` attributes. This variable will be filled
      * as the parsing proceeds with as many LoDs are occured in a file.
      */
-    lods: Number[];
+    lods: string[];
     
     /**
      * Parses a CityJSON file (`data`) and adds it to the `scene`.

--- a/src/parsers/CityJSONWorkerParser.d.ts
+++ b/src/parsers/CityJSONWorkerParser.d.ts
@@ -29,7 +29,7 @@ export class CityJSONWorkerParser {
      * of a vertex based on its `lodid` attributes. This variable will be filled
      * as the parsing proceeds with as many LoDs are occured in a file.
      */
-    lods: Number[];
+    lods: string[];
 
     /**
      * Callback for when a chunk is finished loading


### PR DESCRIPTION
Hi,

From what I've seen, these `lods` are strings, and not pure JS numbers. This is also what's expected from [the spec](https://www.cityjson.org/specs/2.0.1/#geometry-objects):

> A Geometry object:
> * must have one member with the name "lod". The value must be a string with the LoD identifying the level-of-detail (LoD) of the geometry. This can be either a single digit (following the CityGML standards), or "X.Y"-formatted if the [improved LoDs by TU Delft](https://3d.bk.tudelft.nl/lod) are used.