### PR TITLE
Add documentation for GeometryData, BaseParser classes and their methods

### DIFF
--- a/src/parsers/geometry/BaseParser.d.ts
+++ b/src/parsers/geometry/BaseParser.d.ts
@@ -9,7 +9,59 @@ export class BaseParser {
     clean() : void;
 
     /**
-     * Parses the `geom` object.
+     * Retrieves the index of a CityObject from the CityJSON dataset based on its object ID.
+     * 
+     * @param objectId - The unique identifier of the CityObject in the CityJSON dataset.
+     * 
+     * @returns The index of the CityObject in the CityJSON dataset. If the object is not found,
+     *                   the method returns `-1`.
+     */
+    getObjectIdx(objectId: string): number;
+
+    /**
+     * Retrieves the index of a CityObject type from the `objectColors` map based on the provided `cityObjectTypeName`.
+     * 
+     * If the CityObject type (`cityObjectTypeName`) exists in the `objectColors`, its index is returned.
+     * If the type is not found, it is added to `this.objectColors` with a randomly generated color, 
+     * and its index is returned.
+     * 
+     * @param cityObjectTypeName - The name of the CityObject type (e.g., "Building", "BuildingPart", "Bridge", etc.).
+     *                                      This is used to search in `objectColors` and `this.objectColors`.
+     * 
+     * @returns The index of the CityObject type in the `objectColors`.
+     *                   If the type is not found, it is assigned a random color and its index in `this.objectColors` 
+     *                   is returned.
+     */
+    getObjectTypeIdx(cityObjectTypeName: string): number;
+
+    /**
+     * Retrieves the index of a surface type from the CityJSON semantics based on the provided surface index (`idx`).
+     * 
+     * The method checks if the `semantics` array is not empty, and if a valid surface is found at the index `idx`, 
+     * it attempts to find the surface's type within the `this.surfaceColors` object. If the surface type is not present, 
+     * it assigns a random color to that type and returns the new index.
+     * 
+     * @param idx - The index of the current surface, used to access the corresponding semantic value.
+     *                       It refers to an index in the `semantics.values` array.
+     * 
+     * @param semantics - An array of surface indices that correspond to surfaces in the `surfaces` list.
+     * 
+     * @param surfaces - A list of surfaces, where each surface has properties like `type` (e.g., 
+     *                                   "GroundSurface", "RoofSurface", etc.). Each element in `semantics` corresponds
+     *                                   to a surface in this list.
+     * 
+     * @returns The index of the surface type in the `surfaceColors` object. If the surface type 
+     *                   is not found, a new entry is added to `surfaceColors` with a randomly generated color, 
+     *                   and its index is returned. If no valid surface is found, it returns `-1`.
+     */
+    getSurfaceTypeIdx(idx: number, semantics: number[], surfaces: { type: string, [key: string]: any }[]): number;
+
+    /**
+     * Parses the `geom` object
+     * 
+     * @param geom The geometry object representing a CityJSON geometry at a specific LoD
+     * @param objectId The ID of the CityObject in the CityJSON having the `geom` object
+     * @param geomIdx The index of the geometry in the geometry array of the CityObject
      */ 
     parse( geom: Object, objectId: String, geomIdx: Number ): void;
 

--- a/src/parsers/geometry/GeometryData.d.ts
+++ b/src/parsers/geometry/GeometryData.d.ts
@@ -10,18 +10,51 @@ export class GeometryData {
      */
     geometryType : Number;
 
+    /**
+     * Array of vertex indices corresponding to the vertices in the CityJSON `vertices` array. 
+     */
     vertexIds: Number[];
+    /**
+     * Array of CityObject indices. Each entry corresponds to a CityObject that the vertices are associated with.
+     */
     objectIds: Number[];
+    /**
+     * Array of CityObject type indices. Each entry corresponds to the type of the CityObject (e.g., "Building", "Bridge"),
+     * which is indexed from the `defaultObjectColors` or `parser.objectColors`.
+     */
     objectTypes: Number[];
+    /**
+     * Array of surface type indices. Each entry represents the type of surface (e.g., "GroundSurface", "WallSurface")
+     * that a vertex belongs to. The index corresponds to entries in the `surfaceColors` or `defaultSemanticsColors` object.
+     */
     semanticSurfaces: Number[];
+    /**
+     * Array of geometry indices. Each entry refers to the index of a geometry in the CityObject's `geometry` array, 
+     * representing which geometric representation the vertex is part of.
+     */
     geometryIds: Number[];
+    /**
+     * Array of boundary indices. Each entry refers to a boundary or shell in the geometry structure, representing 
+     * which boundary a vertex belongs to.
+     */
     boundaryIds: Number[];
+    /**
+     * Array of Level of Detail (LoD) indices. Each entry corresponds to a LoD level associated with the vertex, 
+     * indicating which LoD geometry representation the vertex is part of.
+     */
     lodIds: Number[];
 
-	constructor(geometryType: any);
+	constructor(geometryType: number);
 
     /**
      * Adds a vertex with the given data
+     * @param vertexId The index of the vertex in the CityJSON `vertices` array.
+     * @param objectId The index of the CityObject this vertex belongs to.
+     * @param objectType  The type of the CityObject (e.g., "Building", "Bridge") as indexed in the `defaultObjectColors` or `parser.objectColors` array.
+     * @param surfaceType The index of the surface type in the `surfaceColors` object. Check `defaultSemanticsColors` for example.
+     * @param geometryIdx The index of the geometry in the CityObject's `geometry` array.
+     * @param boundaryIdx The index of the boundary or shell that this vertex belongs to within the geometry structure.
+     * @param lodIdx The Level of Detail (LoD) index that defines which LoD this vertex is associated with.
      */
     addVertex( vertexId: Number, objectId: Number, objectType: Number, surfaceType: Number, geometryIdx: Number, boundaryIdx: Number, lodIdx: Number ) : void
 


### PR DESCRIPTION
Both the `GeometryData` class and `BaseParser` class currently lacks detailed documentation for its fields and methods. These two classes are important to understand how the parsing is done and what kind of data are being stored in `GeometryData`.


This pull request will improve understanding of how these classes interact with CityJSON data.